### PR TITLE
Solves infinite loop for retry.count

### DIFF
--- a/src/com/qmetry/qaf/automation/testng/pro/QAFTestNGListener2.java
+++ b/src/com/qmetry/qaf/automation/testng/pro/QAFTestNGListener2.java
@@ -183,7 +183,7 @@ public class QAFTestNGListener2 extends QAFTestNGListener
 		final List<LoggingBean> logs = new ArrayList<LoggingBean>(stb.getLog());
 		ITestContext testContext = (ITestContext) tr.getAttribute("context");
 		ReporterUtil.createMethodResult(testContext, tr, logs, checkpoints);
-		if (tr.getStatus() != ITestResult.FAILURE) {
+		if (tr.getStatus() != ITestResult.SKIP) {
 			getBundle().clearProperty(RetryAnalyzer.RETRY_INVOCATION_COUNT);
 		}
 	}


### PR DESCRIPTION
After updating testng 6.9.10  `retry.count`  was broken and goes into infinite loop.
Compatible change in qaf related to https://github.com/cbeust/testng/pull/698 commit (Retriable failures will be reported as SKIP, not FAILURE)