### PR TITLE
support to provide .xml or .loc file location as resources

### DIFF
--- a/src/com/qmetry/qaf/automation/core/ConfigurationManager.java
+++ b/src/com/qmetry/qaf/automation/core/ConfigurationManager.java
@@ -170,8 +170,10 @@ public class ConfigurationManager {
 
 				} else {
 					try {
-						if (fileOrDir.endsWith(".properties")) {
-							p.load(new File[] { resourceFile });
+						if (fileOrDir.endsWith(".properties")
+								|| fileOrDir.endsWith(".xml")
+								|| fileOrDir.endsWith(".loc")) {
+							p.load(new File[]{resourceFile});
 						}
 					} catch (Exception e) {
 						log.error("Unable to load " + resourceFile.getAbsolutePath() + "!", e);


### PR DESCRIPTION
Earlier we were able to provide .properties file or folder as env resources.
Provided support for .xml or .loc file.