### PR TITLE
Updating default locale for test level through Configuration Change Listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /maven
 /build/
 /repository/
+/.settings

--- a/src/com/qmetry/qaf/automation/core/ConfigurationManager.java
+++ b/src/com/qmetry/qaf/automation/core/ConfigurationManager.java
@@ -340,7 +340,6 @@ public class ConfigurationManager {
 					TestBaseProvider.instance().get().tearDown();
 				}
 				String[] bundles = null;
-				// Resource loading
 
 				// Resource loading
 				if (key.equalsIgnoreCase("env.resources")) {
@@ -360,7 +359,14 @@ public class ConfigurationManager {
 						}
 					}
 				}
-
+				// Locale loading
+				if (key.equalsIgnoreCase(ApplicationProperties.DEFAULT_LOCALE.key)) {
+					String[] resources = getBundle().getStringArray("env.resources", "resources");
+					for (String resource : resources) {
+						String fileOrDir = getBundle().getSubstitutor().replace(resource);
+						addLocal(getBundle(), (String) event.getPropertyValue(), fileOrDir);
+					}
+				}
 				// step provider package re-load
 				if (key.equalsIgnoreCase(ApplicationProperties.STEP_PROVIDER_PKG.key)) {
 


### PR DESCRIPTION
env.default.locale for test level can be specified and particular test will execute with that locale as default one.
It has to be loaded by default as it was prior.