### PR TITLE
Solved ClassCastException in fillData

### DIFF
--- a/src/com/qmetry/qaf/automation/data/BaseDataBean.java
+++ b/src/com/qmetry/qaf/automation/data/BaseDataBean.java
@@ -234,7 +234,7 @@ public abstract class BaseDataBean implements DataBean {
 	 */
 	public void fillData(Map<String, String> map) {
 		for (String key : map.keySet()) {
-			fillData(key, map.get(key));
+			fillData(key, String.valueOf(map.get(key)));
 		}
 	}
 


### PR DESCRIPTION
 ClassCastException in fillData: java.lang.Boolean cannot be cast to java.lang.String

It was throwing  ClassCastException in following example.

```java
class UserBean extends BaseDataBean{
private boolean isEmail;
}
```

```java
Map<String, Object> map = new HashedMap();
map.put("isEmail", false);
UserBean bean = new UserBean();
bean.fillData(map);
```

