### PR TITLE
solving multiple issues

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -293,7 +293,7 @@ For any inquiry or need additional information, please contact support-qaf@infos
 	</fileset>
 </path>
 -->
-	<jar destfile="${dist.dir}/qaf-standalone.jar" basedir="${bin.dir}" excludes="**/test/**,**/step/CommonStep.*" includes="**/*.*">
+	<jar destfile="${dist.dir}/qaf-standalone.jar" basedir="${bin.dir}" excludes="**/test/**,**/step/CommonStep.*" includes="**/*.*" duplicate="preserve">
 		<zipgroupfileset dir="${lib.dir}" includes="*.jar" excludes="*sources.jar,*javadoc.jar"/>
 		<zipgroupfileset dir="dependencies" includes="*.jar" excludes="*sources.jar,*javadoc.jar"/>
 

--- a/src/com/qmetry/qaf/automation/step/StringTestStep.java
+++ b/src/com/qmetry/qaf/automation/step/StringTestStep.java
@@ -78,7 +78,6 @@ public class StringTestStep extends BaseTestStep {
 			step = getTestStep();
 			if (null != step) {
 				step.setActualArgs(actualArgs);
-				step.setDescription(description);
 				step.getStepExecutionTracker()
 						.setContext(getStepExecutionTracker().getContext());
 			}

--- a/src/com/qmetry/qaf/automation/step/TestStepListener.java
+++ b/src/com/qmetry/qaf/automation/step/TestStepListener.java
@@ -283,7 +283,7 @@ class TestStepListener implements QAFTestStepListener {
 
 	private String getParam(String text) {
 		String result = getBundle().getSubstitutor().replace(text);
-		String value = String.valueOf(getBundle().getString(result));
+		String value = String.valueOf(getBundle().getObject(result));
 		ParamType ptype = ParamType.getType(value);
 		if (ptype.equals(ParamType.MAP)) {
 			@SuppressWarnings("unchecked")


### PR DESCRIPTION

1. Locator description should display in report instead of key (https://github.com/qmetry/qaf/issues/65)
2. For KWD Scenatio step description should display in report instead of stepName (https://github.com/qmetry/qaf/issues/64)
3. For standalone qaf jar testng classes was not overridden by qaf classes
4. For data driven testcases and for custom steps ${args[0]} was not replaced using actual args in report.