### PR TITLE
For standalone qaf jar testng classes was not overridden by qaf classes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -293,7 +293,7 @@ For any inquiry or need additional information, please contact support-qaf@infos
 	</fileset>
 </path>
 -->
-	<jar destfile="${dist.dir}/qaf-standalone.jar" basedir="${bin.dir}" excludes="**/test/**,**/step/CommonStep.*" includes="**/*.*">
+	<jar destfile="${dist.dir}/qaf-standalone.jar" basedir="${bin.dir}" excludes="**/test/**,**/step/CommonStep.*" includes="**/*.*" duplicate="preserve">
 		<zipgroupfileset dir="${lib.dir}" includes="*.jar" excludes="*sources.jar,*javadoc.jar"/>
 		<zipgroupfileset dir="dependencies" includes="*.jar" excludes="*sources.jar,*javadoc.jar"/>
 


### PR DESCRIPTION
For standalone qaf jar testng classes was not overridden by qaf classes so it was creating issues in BDD Metadata.