### PR TITLE
Unable to capture screenshot for IE driver

### DIFF
--- a/src/com/qmetry/qaf/automation/ui/webdriver/QAFExtendedWebDriver.java
+++ b/src/com/qmetry/qaf/automation/ui/webdriver/QAFExtendedWebDriver.java
@@ -265,7 +265,9 @@ public class QAFExtendedWebDriver extends RemoteWebDriver implements QAFWebDrive
 	 */
 	@Override
 	public <X> X getScreenshotAs(OutputType<X> target) throws WebDriverException {
-		if ((Boolean) getCapabilities().getCapability(CapabilityType.TAKES_SCREENSHOT)) {
+		Object takeScreenshot =
+				getCapabilities().getCapability(CapabilityType.TAKES_SCREENSHOT);
+		if (null == takeScreenshot || (Boolean) takeScreenshot) {
 			String base64Str = execute(DriverCommand.SCREENSHOT).getValue().toString();
 			return target.convertFromBase64Png(base64Str);
 		}


### PR DESCRIPTION
Solving issue for IE, https://github.com/qmetry/qaf/issues/70.
For IE driver in actual capabilities `takesscreenshot` is not found, so QAFWebDriver was not able to take screenshot.
