### PR TITLE
Depends on method not working for scenario resolved

### DIFF
--- a/src/org/testng/DependencyMap.java
+++ b/src/org/testng/DependencyMap.java
@@ -91,7 +91,9 @@ public class DependencyMap {
         // otherwise, it's a method depending on a method in a different class so we
         // don't bother checking the instance
         if (fromMethod.getRealClass().isAssignableFrom(m.getRealClass())) {
-          if (m.getInstance() == fromMethod.getInstance()) return m;
+					if (m.getInstance() == fromMethod.getInstance()
+							|| m.getRealClass().isAssignableFrom(Scenario.class))
+						return m;
         } else {
           return m;
         }


### PR DESCRIPTION
Solved https://github.com/qmetry/qaf/issues/66
Depends on method will work only when both methods class instance is same. For  BDD/KWD Scenario both Scenario class instance would be different, so it was not working. So now for Scenarios it will check methods class name only.