### PR TITLE
CustomDataProvider support for BDD/KWD scenarios

### DIFF
--- a/src/com/qmetry/qaf/automation/step/client/DataDrivenScenario.java
+++ b/src/com/qmetry/qaf/automation/step/client/DataDrivenScenario.java
@@ -21,7 +21,6 @@
  * For any inquiry or need additional information, please contact support-qaf@infostretch.com
  *******************************************************************************/
 
-
 package com.qmetry.qaf.automation.step.client;
 
 import static com.qmetry.qaf.automation.core.ConfigurationManager.getBundle;
@@ -37,6 +36,7 @@ import org.testng.annotations.Test;
 
 import com.qmetry.qaf.automation.step.StringTestStep;
 import com.qmetry.qaf.automation.step.TestStep;
+import com.qmetry.qaf.automation.testng.dataprovider.CustomDataProvider;
 import com.qmetry.qaf.automation.testng.dataprovider.QAFDataProvider.dataproviders;
 import com.qmetry.qaf.automation.testng.dataprovider.QAFDataProvider.params;
 import com.qmetry.qaf.automation.testng.pro.DataProviderUtil;
@@ -125,6 +125,14 @@ public class DataDrivenScenario extends Scenario {
 				return JSONUtil.getJsonArrayOfMaps(param.get(params.JSON_DATA_TABLE.name()));
 			
 			return JSONUtil.getJsonArrayOfMaps(param.get(params.DATAFILE.name()));
+		}
+		if (dataproviderName.equalsIgnoreCase(dataproviders.isfw_custom.name())) {
+			try {
+				Class<?> cls = Class.forName(param.get(params.DATAPROVIDERCLASS.name()));
+				return ((CustomDataProvider) cls.newInstance()).getData(getMetadata());
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
 		}
 		throw new RuntimeException("No data provider found");
 	}

--- a/src/com/qmetry/qaf/automation/testng/dataprovider/CustomDataProvider.java
+++ b/src/com/qmetry/qaf/automation/testng/dataprovider/CustomDataProvider.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * QMetry Automation Framework provides a powerful and versatile platform to author 
+ * Automated Test Cases in Behavior Driven, Keyword Driven or Code Driven approach
+ *                
+ * Copyright 2016 Infostretch Corporation
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+ *
+ * You should have received a copy of the GNU General Public License along with this program in the name of LICENSE.txt in the root folder of the distribution. If not, see https://opensource.org/licenses/gpl-3.0.html
+ *
+ * See the NOTICE.TXT file in root folder of this source files distribution 
+ * for additional information regarding copyright ownership and licenses
+ * of other open source software / files used by QMetry Automation Framework.
+ *
+ * For any inquiry or need additional information, please contact support-qaf@infostretch.com
+ *******************************************************************************/
+
+package com.qmetry.qaf.automation.testng.dataprovider;
+
+import java.util.Map;
+
+public interface CustomDataProvider {
+
+	Object[][] getData(Map<String,Object> metaData);
+}

--- a/src/com/qmetry/qaf/automation/testng/dataprovider/DataProviderFactory.java
+++ b/src/com/qmetry/qaf/automation/testng/dataprovider/DataProviderFactory.java
@@ -114,7 +114,9 @@ public class DataProviderFactory {
 			}
 		}
 		return StringUtil.isNotBlank(map.get(params.SQLQUERY.name())) ? dataproviders.isfw_database.name()
-				: StringUtil.isNotBlank(map.get(params.KEY.name())) ? dataproviders.isfw_property.name() : "";
+				: StringUtil.isNotBlank(map.get(params.KEY.name())) ? dataproviders.isfw_property.name()
+						: StringUtil.isNotBlank(map.get(params.DATAPROVIDERCLASS.name()))
+								? dataproviders.isfw_custom.name() : "";
 	}
 
 	protected static Map<String, String> getParameters(Method method) {

--- a/src/com/qmetry/qaf/automation/testng/dataprovider/QAFDataProvider.java
+++ b/src/com/qmetry/qaf/automation/testng/dataprovider/QAFDataProvider.java
@@ -54,11 +54,11 @@ import java.lang.annotation.Target;
 @Target({ METHOD, TYPE })
 public @interface QAFDataProvider {
 	public enum params {
-		DATAFILE, SHEETNAME, KEY, HASHEADERROW, SQLQUERY, BEANCLASS, JSON_DATA_TABLE;
+		DATAFILE, SHEETNAME, KEY, HASHEADERROW, SQLQUERY, BEANCLASS, JSON_DATA_TABLE, DATAPROVIDERCLASS;
 	}
 
 	public enum dataproviders {
-		isfw_csv, isfw_database, isfw_excel, isfw_excel_table, isfw_json, isfw_property;
+		isfw_csv, isfw_database, isfw_excel, isfw_excel_table, isfw_json, isfw_property, isfw_custom;
 	}
 
 	/**


### PR DESCRIPTION
Follow below steps to use custom data provider.

- Create a new data provider class which implements `CustomDataProvider`.
For example:
```java
public class UserDataProvider implements CustomDataProvider {

	@Override
	public Object[][] getData(Map<String, Object> metaData) {
		List<Object[]> rows = new ArrayList<Object[]>();
		for (int i = 0; i < 10; i++) {
			Map<String, String> map = new HashMap<String, String>();
			map.put("username", "amit" + i);
			map.put("password", "qmetry" + i);
			rows.add(new Object[] { map });
		}
		return rows.toArray(new Object[][] {});
	}
}
```

- In scenario meta-data specify qualified name of class as `dataProviderClass`
```feature
SCENARIO: SampleTest
META-DATA: {"description":"Sample Test Scenario","groups":["SMOKE"],"dataProviderClass":"com.test.UserDataProvider"}
	
	COMMENT: '${username}'
	
END
```