### PR TITLE
Fix #311

### DIFF
--- a/src/com/qmetry/qaf/automation/testng/dataprovider/QAFInetrceptableDataProvider.java
+++ b/src/com/qmetry/qaf/automation/testng/dataprovider/QAFInetrceptableDataProvider.java
@@ -344,7 +344,8 @@ public class QAFInetrceptableDataProvider {
 			} catch (Exception e) {
 				m = getDataProviderMethod(dp, methodClass);
 			}
-			Object instanceToUse = ClassHelper.newInstanceOrNull(m.getDeclaringClass());
+			Object instanceToUse = m.getDeclaringClass().equals(tm.getConstructorOrMethod().getDeclaringClass()) ? tm.getInstance()
+					: ClassHelper.newInstanceOrNull(m.getDeclaringClass());
 			return InvocatoinHelper.invokeDataProvider(instanceToUse, m, tm, c, null,
 					new Configuration().getAnnotationFinder());
 		} else {


### PR DESCRIPTION
If Test and Data provider both methods are of same class, then use same instance else create a new instance of data provider class.